### PR TITLE
Add textblob in setup.py as requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 
-requirements = ['scipy>=1.0.0']
+requirements = ['scipy>=1.0.0', 'textblob>=0.15.3']
 
 setup(
     author="Lucas Shen YS",


### PR DESCRIPTION
Got this error when installing in a fresh virtual env

```
Python 3.7.3 (default, Dec 20 2019, 18:57:59)                                                                                                     
[GCC 8.3.0] on linux                                                                                                                              
Type "help", "copyright", "credits" or "license" for more information.                                                                            
>>> from lexicalrichness import LexicalRichness                                                                                                   
Traceback (most recent call last):                                                                                                                
  File "<stdin>", line 1, in <module>                                                                                                             
  File "~/.local/share/virtualenvs/test/lib/python3.7/site-packages/lexicalrichness/__init__.py", line 10, in <module>          
    from .lexicalrichness import *                                                                                                                
  File "~/.local/share/virtualenvs/test/lib/python3.7/site-packages/lexicalrichness/lexicalrichness.py", line 11, in <module>   
    from textblob import TextBlob                                                                                                                 
ModuleNotFoundError: No module named 'textblob'
```