### PR TITLE
Disallow string input if `tokenizer` =None (closes #12)

### DIFF
--- a/lexicalrichness/lexicalrichness.py
+++ b/lexicalrichness/lexicalrichness.py
@@ -181,6 +181,7 @@ class LexicalRichness(object):
         if self.tokenizer:
             self.wordlist = self.tokenizer(text)
         else:
+            assert type(text)==list, "If tokenizer is None, then input should be a list of words."
             self.wordlist = text
 
         self.words = len(self.wordlist)

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
     packages=find_packages(include=['lexicalrichness']),
     url='https://github.com/LSYS/lexicalrichness',
     download_url='https://github.com/LSYS/LexicalRichness/archive/refs/tags/v0.1.9.tar.gz',
-    version='0.1.9'
+    version='0.1.10'
 )

--- a/tests/test_lexicalrichness.py
+++ b/tests/test_lexicalrichness.py
@@ -5,10 +5,12 @@
 
 
 import unittest
-
-# from lexicalrichness import lexicalrichness
-from lexicalrichness.lexicalrichness import *
-# import textblob
+from lexicalrichness.lexicalrichness import LexicalRichness
+from lexicalrichness.lexicalrichness import preprocess
+from lexicalrichness.lexicalrichness import tokenize
+from lexicalrichness.lexicalrichness import list_sliding_window
+from lexicalrichness.lexicalrichness import segment_generator
+import pytest
 
 
 class TestLexicalrichness(unittest.TestCase):
@@ -45,13 +47,13 @@ class TestLexicalrichness(unittest.TestCase):
         self.assertIs(type(tokenize(self.s3)), list)
         self.assertIs(type(tokenize(self.emptystring)), list)
 
-    # def test_blobber(self):
-    #     print('testing blobber')
 
-    #     self.assertIs(type(blobber(self.s1)), textblob.blob.WordList)
-    #     self.assertIs(type(blobber(self.s2)), textblob.blob.WordList)
-    #     self.assertIs(type(blobber(self.s3)), textblob.blob.WordList)
-    #     self.assertIs(type(blobber(self.emptystring)), textblob.blob.WordList)
+    def test_tokenize_str_error(self):
+        """Ensures error is raised if tokenizer is set to None and input is a string."""
+        with pytest.raises(AssertionError) as err:
+            LexicalRichness(self.s1, tokenizer=None)
+        assert str(err.value) == "If tokenizer is None, then input should be a list of words."
+
 
     def test_list_sliding_window(self):
         print('testing list_sliding_window')


### PR DESCRIPTION
- Removing the gotcha where string inputs can still be accepted into the LexicalRichness class when `tokenizer` is set to None. Input should be a list of strings. Closes #12